### PR TITLE
add delay to comply request limit of upbit api

### DIFF
--- a/src/main/java/gitp/upbitapi/api/UpbitCandleApiClient.java
+++ b/src/main/java/gitp/upbitapi/api/UpbitCandleApiClient.java
@@ -12,6 +12,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -69,7 +70,8 @@ public class UpbitCandleApiClient {
             responseMonoList.add(candleWebClient);
         }
 
-        return Flux.merge(responseMonoList);
+        return Flux.concat(responseMonoList)
+                .delayElements(Duration.ofMillis(100));
     }
 }
 

--- a/src/test/java/gitp/upbitapi/api/UpbitCandleApiClientTest.java
+++ b/src/test/java/gitp/upbitapi/api/UpbitCandleApiClientTest.java
@@ -5,6 +5,8 @@ import gitp.upbitapi.api.timeutil.SplitPeriodIterator;
 import gitp.upbitapi.domain.MarketCode;
 import gitp.upbitapi.dto.CandleDto;
 import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,6 +16,7 @@ import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.IntStream;
 
 @SpringBootTest
 @Slf4j
@@ -51,5 +54,41 @@ class UpbitCandleApiClientTest {
                 .forEach(candleDto -> System.out.println(candleDto.getCandleDateTimeUtc()));
 
 
+    }
+
+    @Test
+    @DisplayName("limit of upbit api request: 10 times per second")
+    void requestLimitTest() throws Exception {
+        //given
+
+        final int batchSize = 50;
+
+        LocalDateTime startTime = LocalDateTime.of(2023, 8, 23, 7, 11, 0);
+        LocalDateTime endTime = LocalDateTime.of(2023, 8, 24, 8, 52, 30);
+
+        SplitPeriodIterator splitIter = PeriodSplitter.split(startTime, endTime, batchSize, 1);
+
+        //when
+        List<List<CandleDto>> responseCandles = apiClient.getMinuteCandle(splitIter, MarketCode.BIT_COIN, 1)
+                .collectList()
+                .block();
+
+        List<CandleDto> sortedCandleDtoList = responseCandles.stream()
+                .flatMap(Collection::stream)
+                .sorted(Comparator.comparing(CandleDto::getCandleDateTimeUtc))
+                .toList();
+
+        boolean disContinuousFlag = IntStream.iterate(0, i -> i + 1)
+                .limit(responseCandles.size() - 1)
+                .anyMatch(i ->
+                        LocalDateTime.parse(sortedCandleDtoList.get(i)
+                                        .getCandleDateTimeUtc())
+                                .plusMinutes(1L)
+                                .equals(LocalDateTime.parse(sortedCandleDtoList.get(i)
+                                        .getCandleDateTimeUtc()))
+                );
+
+        Assertions.assertThat(disContinuousFlag)
+                .isEqualTo(false);
     }
 }


### PR DESCRIPTION
- merge -> concat로 mono들을 flux로 병함하는 연산자를 변경함으로써 1초에 10회 요청 제한을 지키는 코드 작성